### PR TITLE
correct passthru of parameters

### DIFF
--- a/sources/usr/bin/AutoFirma
+++ b/sources/usr/bin/AutoFirma
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar /usr/lib/AutoFirma/AutoFirma.jar $*
+java -jar /usr/lib/AutoFirma/AutoFirma.jar "$@"


### PR DESCRIPTION
Using quotes and `$@` instead of `$*` are needed 
in order to correctly passthru parameters with spaces
other weird characters often needed when using
AutoFirma via cli parameters, specially -config parameter.

For example if you require pass the layer2Text parameter
and has spaces:

```bash
AutoFirma -config "Layer2Text=Hola mundo\n"
```

The pre-patched intermediate script will split parameters like
 - `-config`
 - `Layer2Text=Hola`
 - `mundo\n`
 
 While the patched script will split it properly as:
 - `-config`
 - `Layer2Text=Hola mundo\n`

Respecting the quotes given by the user from bash.